### PR TITLE
Use MINIKUBE_HOME env var if exist

### DIFF
--- a/scripts/configure-minikube.sh
+++ b/scripts/configure-minikube.sh
@@ -9,10 +9,13 @@ set -euo pipefail
 #curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 #sudo install minikube-linux-amd64 /usr/local/bin/minikube
 
+# Default minkube home to user home, if MINIKUBE_HOME is not defined
+MINIKUBE_HOME_=${MINIKUBE_HOME:=$HOME}
 
 export BRIDGE_K8S_AUTH_BEARER_TOKEN=${BRIDGE_K8S_AUTH_BEARER_TOKEN:="31ada4fd-adec-460c-809a-9e56ceb75269"}
 # Prepare user with token
-echo "${BRIDGE_K8S_AUTH_BEARER_TOKEN},forklift,0" > ~/.minikube/files/etc/ca-certificates/token.csv
+mkdir -p ${MINIKUBE_HOME_}/.minikube/files/etc/ca-certificates
+echo "${BRIDGE_K8S_AUTH_BEARER_TOKEN},forklift,0" > ${MINIKUBE_HOME_}/.minikube/files/etc/ca-certificates/token.csv
 
 echo "Starting local minikube console..."
 


### PR DESCRIPTION
We currently assume minikube is installed using default user home directory, but minikube can also use MINIKUBE_HOME [1]

[1] https://minikube.sigs.k8s.io/docs/handbook/config/#environment-variables