### PR TITLE
Use podman --env parameter

### DIFF
--- a/scripts/start-console-minikube.sh
+++ b/scripts/start-console-minikube.sh
@@ -39,19 +39,19 @@ PLUGIN_PROXY=$(cat << END
     }]}
 END
 )
-BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
+export BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
 
 # Prefer podman if installed. Otherwise, fall back to docker.
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
-        podman run --pull always --rm --network=host --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
+        podman run --pull always --rm --network=host --env "BRIDGE_*" $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
-        podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+        podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env "BRIDGE_*" $CONSOLE_IMAGE
     fi
 else
     BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
-    docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+    docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep ^BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
 fi

--- a/scripts/start-console-with-oauth.sh
+++ b/scripts/start-console-with-oauth.sh
@@ -41,20 +41,20 @@ oc get secrets -n default \
    jq '.items[0].data."ca.crt"' -r | python -m base64 -d > $(pwd)/tmp/ca.crt
 
 # Fill in console bridge parameters
-BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE="/mnt/config/console-client-secret"
-BRIDGE_CA_FILE="/mnt/config/ca.crt"
-BRIDGE_USER_AUTH_OIDC_CA_FILE="/mnt/config/ca.crt"
+export BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE="/mnt/config/console-client-secret"
+export BRIDGE_CA_FILE="/mnt/config/ca.crt"
+export BRIDGE_USER_AUTH_OIDC_CA_FILE="/mnt/config/ca.crt"
 
-BRIDGE_BASE_ADDRESS="http://localhost:9000"
-BRIDGE_K8S_MODE="off-cluster"
-BRIDGE_K8S_AUTH="openshift"
-BRIDGE_USER_AUTH="openshift"
-BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client-dev"
-BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
-BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
-BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
-BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
-BRIDGE_USER_SETTINGS_LOCATION="localstorage"
+export BRIDGE_BASE_ADDRESS="http://localhost:9000"
+export BRIDGE_K8S_MODE="off-cluster"
+export BRIDGE_K8S_AUTH="openshift"
+export BRIDGE_USER_AUTH="openshift"
+export BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client-dev"
+export BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
+export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
+export BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
@@ -77,19 +77,19 @@ PLUGIN_PROXY=$(cat << END
     }]}
 END
 )
-BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
+export BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
 
 # Prefer podman if installed. Otherwise, fall back to docker.
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
-        podman run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z --network=host --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
+        podman run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z --network=host --env "BRIDGE_*" $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
-        podman run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+        podman run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z -p "$CONSOLE_PORT":9000 --env "BRIDGE_*" $CONSOLE_IMAGE
     fi
 else
     BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
-    docker run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+    docker run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z -p "$CONSOLE_PORT":9000 --env-file <(set | grep ^BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
 fi

--- a/scripts/start-console.sh
+++ b/scripts/start-console.sh
@@ -10,15 +10,15 @@ MUST_GATHER_API_SERVER_HOST=${MUST_GATHER_API_SERVER_HOST:="http://localhost:920
 
 echo "Starting local OpenShift console..."
 
-BRIDGE_USER_AUTH="disabled"
-BRIDGE_K8S_MODE="off-cluster"
-BRIDGE_K8S_AUTH="bearer-token"
-BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
-BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
-BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
-BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
-BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
-BRIDGE_USER_SETTINGS_LOCATION="localstorage"
+export BRIDGE_USER_AUTH="disabled"
+export BRIDGE_K8S_MODE="off-cluster"
+export BRIDGE_K8S_AUTH="bearer-token"
+export BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
+export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
+export BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+export BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
@@ -41,19 +41,19 @@ PLUGIN_PROXY=$(cat << END
     }]}
 END
 )
-BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
+export BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
 
 # Prefer podman if installed. Otherwise, fall back to docker.
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
-        podman run --pull always --rm --network=host --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
+        podman run --pull always --rm --network=host --env "BRIDGE_*" $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
-        podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+        podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env "BRIDGE_*" $CONSOLE_IMAGE
     fi
 else
     BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
-    docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
+    docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep ^BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
 fi


### PR DESCRIPTION
As suggested by @nirs podman support `--env` parameter [1] that is nicer then the `--env-file` parameter we use for docker.

[1] https://docs.podman.io/en/latest/markdown/podman-run.1.html#env-e-env