### PR TITLE
Use primary button style for create actions

### DIFF
--- a/pkg/web/src/app/Mappings/MappingsPage.tsx
+++ b/pkg/web/src/app/Mappings/MappingsPage.tsx
@@ -45,7 +45,7 @@ const MappingsPage: React.FunctionComponent = () => {
           <LevelItem>
             <CreateMappingButton
               aria-label={`Create ${activeMapType} mapping`}
-              variant="secondary"
+              variant="primary"
               label="Create mapping"
               onClick={toggleModalAndResetEdit}
             />

--- a/pkg/web/src/app/Providers/ProvidersPage.tsx
+++ b/pkg/web/src/app/Providers/ProvidersPage.tsx
@@ -109,7 +109,7 @@ export const ProvidersPage: React.FunctionComponent = () => {
             <Title headingLevel="h1">Providers</Title>
           </LevelItem>
           <LevelItem>
-            <Button variant="secondary" onClick={() => toggleModalAndResetEdit()}>
+            <Button variant="primary" onClick={() => toggleModalAndResetEdit()}>
               Add provider
             </Button>
           </LevelItem>


### PR DESCRIPTION
Console uses primary button style for creating resources. 
Note that only Migrations and Providers screens are affected. On Plans screen we have multiple actions  i.e. Start plan action (per each plan).