### PR TITLE
Replace `@konveyor/lib-ui` with `@migtools/lib-ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "helm:build": "mkdir -p tmp && helm package -d tmp deployment/forklift-console-plugin/ && yarn helm:index"
   },
   "devDependencies": {
-    "@konveyor/lib-ui": "^8.3.2",
+    "@migtools/lib-ui": "^8.4.1",
     "@openshift-console/dynamic-plugin-sdk": "0.0.12",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.7",
     "@patternfly/react-core": "4.175.4",

--- a/pkg/web/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/pkg/web/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -11,7 +11,7 @@ import {
   FormGroup,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { useFormField, useFormState, ValidatedTextInput } from '@konveyor/lib-ui';
+import { useFormField, useFormState, ValidatedTextInput } from '@migtools/lib-ui';
 import { SimpleSelect, OptionWithValue } from '@app/common/components/SimpleSelect';
 import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema } from './MappingBuilder';
 import { getMappingFromBuilderItems } from './MappingBuilder/helpers';

--- a/pkg/web/src/app/Mappings/components/MappingStatus.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon } from '@konveyor/lib-ui';
+import { StatusIcon } from '@migtools/lib-ui';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { useResourceQueriesForMapping } from '@app/queries';
 import { MappingType, Mapping } from '@app/queries/types';

--- a/pkg/web/src/app/Mappings/components/MappingsTable.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingsTable.tsx
@@ -13,7 +13,7 @@ import {
   truncate,
 } from '@patternfly/react-table';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
-import { useSelectionState } from '@konveyor/lib-ui';
+import { useSelectionState } from '@migtools/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
 import { IMetaObjectMeta, Mapping, MappingType } from '@app/queries/types';
 import { MappingsActionsDropdown } from './MappingsActionsDropdown';

--- a/pkg/web/src/app/Plans/components/PlanDetails.tsx
+++ b/pkg/web/src/app/Plans/components/PlanDetails.tsx
@@ -14,7 +14,7 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { StatusIcon } from '@konveyor/lib-ui';
+import { StatusIcon } from '@migtools/lib-ui';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 
 import { MappingDetailView } from '@app/Mappings/components/MappingDetailView';

--- a/pkg/web/src/app/Plans/components/PlansTable.tsx
+++ b/pkg/web/src/app/Plans/components/PlansTable.tsx
@@ -31,7 +31,7 @@ import ArchiveIcon from '@patternfly/react-icons/dist/esm/icons/archive-icon';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Link } from 'react-router-dom';
-import { StatusIcon, useSelectionState } from '@konveyor/lib-ui';
+import { StatusIcon, useSelectionState } from '@migtools/lib-ui';
 
 import { PlanActionsDropdown } from './PlanActionsDropdown';
 import { useSortState, usePaginationState } from '@app/common/hooks';

--- a/pkg/web/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/pkg/web/src/app/Plans/components/VMMigrationDetails.tsx
@@ -29,7 +29,7 @@ import {
 } from '@patternfly/react-table';
 import { centerCellTransform } from '@app/utils/utils';
 import { Link } from 'react-router-dom';
-import { useSelectionState } from '@konveyor/lib-ui';
+import { useSelectionState } from '@migtools/lib-ui';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
 

--- a/pkg/web/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/pkg/web/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -12,7 +12,7 @@ import {
 
 import { IVMStatus } from '@app/queries/types';
 import { TickingElapsedTime } from '@app/common/components/TickingElapsedTime';
-import { StatusIcon } from '@konveyor/lib-ui';
+import { StatusIcon } from '@migtools/lib-ui';
 import { CanceledIcon } from '@app/common/components/CanceledIcon';
 
 interface IVMStatusPrecopyTableProps {

--- a/pkg/web/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/pkg/web/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IVMStatus } from '@app/queries/types';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon, StatusType } from '@migtools/lib-ui';
 import { Button, Popover } from '@patternfly/react-core';
 import { getMinutesUntil } from '@app/common/helpers';
 import { CanceledIcon } from '@app/common/components/CanceledIcon';

--- a/pkg/web/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -12,7 +12,7 @@ import {
   TreeViewSearch,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { useSelectionState } from '@konveyor/lib-ui';
+import { useSelectionState } from '@migtools/lib-ui';
 import { IndexedTree, useSourceVMsQuery } from '@app/queries';
 import {
   IPlan,

--- a/pkg/web/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -13,7 +13,7 @@ import {
   Popover,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
+import { getFormGroupProps, ValidatedTextInput } from '@migtools/lib-ui';
 
 import { POD_NETWORK } from '@app/queries/types';
 import {

--- a/pkg/web/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -16,7 +16,7 @@ import {
   Divider,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { ValidatedTextInput } from '@konveyor/lib-ui';
+import { ValidatedTextInput } from '@migtools/lib-ui';
 import { OptionWithValue } from '@app/common/components/SimpleSelect';
 import {
   MappingType,

--- a/pkg/web/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -7,7 +7,7 @@ import {
   useFormField,
   useFormState,
   ValidatedTextInput,
-} from '@konveyor/lib-ui';
+} from '@migtools/lib-ui';
 import {
   Modal,
   Stack,

--- a/pkg/web/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -14,7 +14,7 @@ import {
 import { Link, Redirect, useHistory, useRouteMatch } from 'react-router-dom';
 import { UseQueryResult } from 'react-query';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { useFormField, useFormState } from '@konveyor/lib-ui';
+import { useFormField, useFormState } from '@migtools/lib-ui';
 import { RouteGuard } from '@app/common/components/RouteGuard';
 import { WizardStepContainer } from './WizardStepContainer';
 import { GeneralForm } from './GeneralForm';

--- a/pkg/web/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -38,7 +38,7 @@ import {
   InventoryTree,
   InventoryTreeType,
 } from '@app/queries/types';
-import { useSelectionState } from '@konveyor/lib-ui';
+import { useSelectionState } from '@migtools/lib-ui';
 
 import { useSortState, usePaginationState, useFilterState } from '@app/common/hooks';
 import { PlanWizardFormState } from './PlanWizard';

--- a/pkg/web/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -4,7 +4,7 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
 import { warmCriticalConcerns, someVMHasConcern } from './helpers';
 import { SourceVM } from '@app/queries/types';
-import { StatusIcon } from '@konveyor/lib-ui';
+import { StatusIcon } from '@migtools/lib-ui';
 
 interface ITypeFormProps {
   form: PlanWizardFormState['type'];

--- a/pkg/web/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon } from '@konveyor/lib-ui';
+import { StatusIcon } from '@migtools/lib-ui';
 import { TextContent, Text, List, ListItem, Flex, FlexItem } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PRODUCT_DOCO_LINK } from '@app/common/constants';

--- a/pkg/web/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SourceVM } from '@app/queries/types';
-import { StatusIcon } from '@konveyor/lib-ui';
+import { StatusIcon } from '@migtools/lib-ui';
 
 import { getMostSevereVMConcern, getVMConcernStatusLabel, getVMConcernStatusType } from './helpers';
 interface IVMConcernsIconProps {

--- a/pkg/web/src/app/Plans/components/Wizard/helpers.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/helpers.tsx
@@ -52,7 +52,7 @@ import {
   IDisk,
 } from '@app/queries';
 import { UseQueryResult, QueryStatus } from 'react-query';
-import { StatusType } from '@konveyor/lib-ui';
+import { StatusType } from '@migtools/lib-ui';
 import { PlanHookInstance } from './PlanAddEditHookModal';
 import { IKubeList } from '@app/client/types';
 import { getObjectRef } from '@app/common/helpers';

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -28,7 +28,7 @@ import {
   getFormGroupProps,
   ValidatedTextInput,
   ValidatedPasswordInput,
-} from '@konveyor/lib-ui';
+} from '@migtools/lib-ui';
 
 import { SimpleSelect, OptionWithValue } from '@app/common/components/SimpleSelect';
 import {

--- a/pkg/web/src/app/Providers/components/CloudAnalyticsInfoAlert.tsx
+++ b/pkg/web/src/app/Providers/components/CloudAnalyticsInfoAlert.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert, AlertActionCloseButton, Text } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { useLocalStorage } from '@konveyor/lib-ui';
+import { useLocalStorage } from '@migtools/lib-ui';
 import { CLOUD_MA_LINK, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 export const CloudAnalyticsInfoAlert: React.FunctionComponent = () => {

--- a/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -7,7 +7,7 @@ import {
   getFormGroupProps,
   ValidatedTextInput,
   ValidatedPasswordInput,
-} from '@konveyor/lib-ui';
+} from '@migtools/lib-ui';
 
 import { SimpleSelect, OptionWithValue } from '@app/common/components/SimpleSelect';
 import { IHost, IHostConfig, IHostNetworkAdapter, IVMwareProvider } from '@app/queries/types';

--- a/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -11,7 +11,7 @@ import {
   truncate,
 } from '@patternfly/react-table';
 import { usePaginationState, useSortState } from '@app/common/hooks';
-import { StatusIcon, useSelectionState } from '@konveyor/lib-ui';
+import { StatusIcon, useSelectionState } from '@migtools/lib-ui';
 import { IHost, IVMwareProvider } from '@app/queries/types';
 import { SelectNetworkModal } from './SelectNetworkModal';
 import { useHostConfigsQuery } from '@app/queries';

--- a/pkg/web/src/app/client/helpers.ts
+++ b/pkg/web/src/app/client/helpers.ts
@@ -4,7 +4,7 @@ import KubeClient, {
   NamespacedResource,
   CoreNamespacedResourceKind,
   CoreNamespacedResource,
-} from '@konveyor/lib-ui';
+} from '@migtools/lib-ui';
 import { META, ProviderType, CLUSTER_API_VERSION } from '@app/common/constants';
 import { IProviderObject, ISecret } from '@app/queries/types';
 import { useNetworkContext } from '@app/common/context';

--- a/pkg/web/src/app/client/types.ts
+++ b/pkg/web/src/app/client/types.ts
@@ -1,5 +1,5 @@
 import { IMetaObjectMeta, IMetaTypeMeta } from '@app/queries/types';
-import { ClusterClient } from '@konveyor/lib-ui';
+import { ClusterClient } from '@migtools/lib-ui';
 import { AxiosError } from 'axios';
 
 export type KubeClientError = AxiosError<{ message: string }>;

--- a/pkg/web/src/app/common/components/ProviderSelect.tsx
+++ b/pkg/web/src/app/common/components/ProviderSelect.tsx
@@ -6,7 +6,7 @@ import {
   IProviderObject,
   SourceInventoryProvider,
 } from '@app/queries/types';
-import { getFormGroupProps, IValidatedFormField } from '@konveyor/lib-ui';
+import { getFormGroupProps, IValidatedFormField } from '@migtools/lib-ui';
 import {
   Divider,
   FormGroup,

--- a/pkg/web/src/app/common/components/SelectOpenShiftNetworkModal.tsx
+++ b/pkg/web/src/app/common/components/SelectOpenShiftNetworkModal.tsx
@@ -10,7 +10,7 @@ import {
   TextContent,
   Text,
 } from '@patternfly/react-core';
-import { useFormState, useFormField, getFormGroupProps } from '@konveyor/lib-ui';
+import { useFormState, useFormField, getFormGroupProps } from '@migtools/lib-ui';
 
 import { SimpleSelect, OptionWithValue } from '@app/common/components/SimpleSelect';
 import {

--- a/pkg/web/src/app/common/components/StatusCondition.tsx
+++ b/pkg/web/src/app/common/components/StatusCondition.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon, StatusType } from '@migtools/lib-ui';
 import { getMostSeriousCondition } from '@app/common/helpers';
 import { StatusCategoryType } from '@app/common/constants';
 import { IStatusCondition } from '@app/queries/types';

--- a/pkg/web/src/app/common/context/NetworkContext.tsx
+++ b/pkg/web/src/app/common/context/NetworkContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { AxiosError } from 'axios';
 import { History } from 'history';
-import { useLocalStorage } from '@konveyor/lib-ui';
+import { useLocalStorage } from '@migtools/lib-ui';
 import { PATH_PREFIX } from '../constants';
 
 export interface ICurrentUser {

--- a/pkg/web/src/app/queries/fetchHelpers.ts
+++ b/pkg/web/src/app/queries/fetchHelpers.ts
@@ -3,7 +3,7 @@ import { QueryFunction } from 'react-query/types/core/types';
 import { useHistory } from 'react-router-dom';
 import { History, LocationState } from 'history';
 import { useClientInstance } from '@app/client/helpers';
-import { KubeResource } from '@konveyor/lib-ui';
+import { KubeResource } from '@migtools/lib-ui';
 import { IKubeResponse, IKubeStatus } from '@app/client/types';
 import { ENV } from '@app/common/constants';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,19 +618,19 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@konveyor/lib-ui@^8.3.2":
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-8.3.2.tgz#f7b5ac010ff96e505227ed9b5ae98ac0d1c26287"
-  integrity sha512-AZD00BB5Ju46OL2zci5qSdkxgull/UF5M9T2oUKOzxLa+af43/49Xvz9JTU1gBZFixJYDuWRWqblRlWxP9s6jw==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    react-query "^3.26.0"
-    yup "^0.32.9"
-
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
+"@migtools/lib-ui@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@migtools/lib-ui/-/lib-ui-8.4.1.tgz#d10e33ab03ee9cd87ccb01e181451d2b79c5ec0b"
+  integrity sha512-QJEh3Vq7IkHcRCiOQh3NhX30b8BvHB1XBBkbGyp+lcwP90pPl/ateOJzac1v44OIa7DAgK4iNS+v+hay3EK5cg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    react-query "^3.26.0"
+    yup "^0.32.9"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
The `@konveyor/lib-ui` package has been migrated from the `konveyor` org to the `migtools` org as part of Konveyor being [donated to the CNCF Sandbox](https://www.konveyor.io/blog/konveyor-is-a-cncf-sandbox-project/). The npm package has been renamed to `@migtools/lib-ui` starting with the `8.4.1` release (see https://github.com/migtools/lib-ui/pull/111).

The only changes since `@konveyor/lib-ui@8.3.2` were the addition of name change warnings in `8.4.0` and then the package rename in `8.4.1`, so renaming imports is the only source change necessary here.

See also:
* https://github.com/konveyor/forklift-ui/pull/984
* https://github.com/konveyor/mig-ui/pull/1471
* https://github.com/migtools/crane-ui-plugin/pull/134
* https://github.com/konveyor/tackle2-ui/pull/375