### PR TITLE
Add helpers to deploy forklift on k8s

### DIFF
--- a/deployment/hack/dev-route/forklift-inventory.yaml
+++ b/deployment/hack/dev-route/forklift-inventory.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: forklift-inventory-serving-cert
+  name: forklift-inventory
+  namespace: konveyor-forklift
+spec:
+  ports:
+  - name: api-http
+    nodePort: 30080
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  sessionAffinity: None
+  type: NodePort

--- a/scripts/configure-minikube.sh
+++ b/scripts/configure-minikube.sh
@@ -21,7 +21,11 @@ echo "${K8S_AUTH_BEARER_TOKEN},forklift,0" > ${MINIKUBE_HOME_}/.minikube/files/e
 echo "Starting local minikube console..."
 
 # Start minikube
-minikube start --extra-config=apiserver.token-auth-file=/etc/ca-certificates/token.csv
+if [ -x "$(command -v podman)" ]; then
+    minikube start --extra-config=apiserver.token-auth-file=/etc/ca-certificates/token.csv --memory=6G --cpus=4 --driver=podman
+else
+    minikube start --extra-config=apiserver.token-auth-file=/etc/ca-certificates/token.csv
+fi
 
 # Install CRDs
 kubectl apply -f $(pwd)/deployment/hack/crds

--- a/scripts/k8s-deploy-forklift.sh
+++ b/scripts/k8s-deploy-forklift.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -ex
+
+# Install olm
+kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/crds.yaml
+kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
+
+# Wait for olm operator to start
+while ! kubectl get deployment -n olm olm-operator; do sleep 10; done
+kubectl wait deployment -n olm olm-operator --for condition=Available=True --timeout=180s
+
+# Install forklift-operator
+export FORK_RELEASE=$(curl -s https://api.github.com/repos/konveyor/forklift-operator/branches | jq ". | last .name" | tr -d '"')
+kubectl apply -f https://raw.githubusercontent.com/konveyor/forklift-operator/${FORK_RELEASE}/forklift-k8s.yaml
+
+# --------------------
+
+# Wait for forklift operator to start, and create a controller instance
+while ! kubectl get deployment -n konveyor-forklift forklift-operator; do sleep 10; done
+kubectl wait deployment -n konveyor-forklift forklift-operator --for condition=Available=True --timeout=180s
+
+cat << EOF | kubectl -n konveyor-forklift apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: konveyor-forklift
+spec:
+  feature_ui: false
+  feature_validation: true
+  inventory_tls_enabled: false
+  validation_tls_enabled: false
+  must_gather_api_tls_enabled: false
+  ui_tls_enabled: false
+EOF
+
+echo Forklift: $FORK_RELEASE

--- a/scripts/k8s-deploy-kubevirt.sh
+++ b/scripts/k8s-deploy-kubevirt.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -ex
+
+# Install CDI
+export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+
+# Install CNA
+export CNA_VERSION=$(curl -s https://api.github.com/repos/kubevirt/cluster-network-addons-operator/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/$CNA_VERSION/namespace.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/$CNA_VERSION/network-addons-config.crd.yaml
+kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/$CNA_VERSION/operator.yaml
+
+# Install kubevirt
+export VIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- '-rc' | sort -r | head -1 | awk -F': ' '{print $2}' | sed 's/,//' | xargs)
+kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VIRT_VERSION}/kubevirt-operator.yaml
+kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VIRT_VERSION}/kubevirt-cr.yaml
+
+# --------------------
+
+# Wait for cluster-network-addons operator to start
+while ! kubectl get deployment -n cluster-network-addons cluster-network-addons-operator; do sleep 10; done
+kubectl wait deployment -n cluster-network-addons cluster-network-addons-operator --for condition=Available=True --timeout=180s
+
+# Install macvtap and multus
+cat << EOF | kubectl apply -f -
+apiVersion: networkaddonsoperator.network.kubevirt.io/v1
+kind: NetworkAddonsConfig
+metadata:
+  name: cluster
+  namespace: cluster-network-addons
+spec:
+  multus: {}
+  linuxBridge: {}
+  macvtap: {}
+  imagePullPolicy: Always
+EOF
+
+# Wait for NADs to be ready, and create an empty NAD
+while ! kubectl get network-attachment-definitions.k8s.cni.cncf.io; do sleep 10; done
+cat << EOF | kubectl apply -f -
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: example
+  namespace: cluster-network-addons
+spec:
+  config: '{}'
+EOF
+
+echo CDI:  $CDI_VERSION
+echo CNA:  $CNA_VERSION
+echo Virt: $VIRT_VERSION


### PR DESCRIPTION
Add helpers to deploy forklift on k8s or minikube

  - forklift-inventory.yaml                - replace the cluster internal `forklift-inventory` service with a nodePort one.
  - k8s-deploy-forklift.sh          - helper script to deploy forklift operator on k8s.
  - k8s-deploy-kubevirt.sh - helper script to deploy CDI, CNA and kubevirt on k8s.

Work flow:

A. create minikube cluster
To initiate a minikube cluster with a forklift (has cluster-admin role) user:
``` bash
# optional, set the forklift user bearer token (default is "31ada4fd-adec-460c-809a-9e56ceb75269"):
# export K8S_AUTH_BEARER_TOKEN="31ada4fd-adec-460c-809a-9e56ceb75269"
bash ./scripts/configure-minikube.sh
```

B. install required operators
A hub (running forklift controller) minikube cluster requires:
``` bash
bash ./scripts/k8s-deploy-forklift.sh
```

A target (running kubevirt controller) minikube cluster requires:
``` bash
bash ./scripts/k8s-deploy-kubevirt.sh
```

C. run the UI
``` bash
# start the console server
# use local running forklift operator running on http://localhost:8080
yarn start:console:minikube
# if the cluster inventory server use "feature_auth_required=false" and 
# "inventory_tls_enabled=false" you can use that server
INVENTORY_SERVER_HOST=http://$(minikube ip):30080 yarn start:console:minikube

# on a different terminal, start the plugin
DATA_SOURCE=dynamic yarn start
```