### PR TITLE
Rename the navigation section name to VM Import

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -4,7 +4,7 @@
     "properties": {
       "id": "migrationtoolkit",
       "perspective": "admin",
-      "name": "%plugin__forklift-console-plugin~Migration Toolkit%",
+      "name": "%plugin__forklift-console-plugin~VM Import%",
       "insertAfter": "workloads"
     }
   },

--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -1,7 +1,7 @@
 {
-  "Migration Toolkit": "Migration Toolkit",
   "NetworkMaps": "NetworkMaps",
   "Plans": "Plans",
   "Providers": "Providers",
-  "StorageMaps": "StorageMaps"
+  "StorageMaps": "StorageMaps",
+  "VM Import": "VM Import"
 }

--- a/src/internal/i18n/i18n.ts
+++ b/src/internal/i18n/i18n.ts
@@ -3,7 +3,7 @@ import { useTranslation as useReactI18NextTranslation } from 'react-i18next';
 // IMPORTANT: This file adds comments recognized by the react-i18next-parser so that
 // labels declared in console-extensions.json are added to the message catalog.
 
-// t('plugin__forklift-console-plugin~Migration Toolkit')
+// t('plugin__forklift-console-plugin~VM Import')
 // t('plugin__forklift-console-plugin~Providers')
 // t('plugin__forklift-console-plugin~Plans')
 // t('plugin__forklift-console-plugin~NetworkMaps')


### PR DESCRIPTION
Issue:
"Migration tools" does not convey the virtualization aspect of the navigation item
"Migration tools" overload the semantic of the migration word that is already used in indicate node to node migration

Proposed solution:
Use "VM Import" that indicate "VM" and does not use the word migration.

Screenshot:
![vm import](https://user-images.githubusercontent.com/2181522/187722657-4a934890-6e47-4c64-a088-3fd2bbba7fe3.png)

Signed-off-by: yzamir <yzamir@redhat.com>