### PR TITLE
Update default quay image

### DIFF
--- a/deployment/forklift-console-plugin/values.yaml
+++ b/deployment/forklift-console-plugin/values.yaml
@@ -1,5 +1,5 @@
 plugin: forklift-console-plugin
 name: forklift-console-plugin
-image: quay.io/yaacov/forklift-console-plugin:latest
+image: quay.io/kubevirt-ui/forklift-console-plugin:latest
 
 forkliftNamespace: konveyor-forklift


### PR DESCRIPTION
The projects quay image is now built in:
[quay.io/kubevirt-ui/forklift-console-plugin](https://quay.io/kubevirt-ui/forklift-console-plugin)