### PR TITLE
Move menu items into virtualization section

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -2,39 +2,65 @@
   {
     "type": "console.navigation/section",
     "properties": {
-      "id": "migrationtoolkit",
+      "id": "virtualization",
+      "name": "%plugin__kubevirt-plugin~Virtualization%",
+      "insertAfter": "workloads",
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-sec-virtualization",
+        "data-test-id": "virtualization-nav-item"
+      }
+    },
+    "flags": {
+      "disallowed": [
+        "KUBEVIRT_DYNAMIC"
+      ]
+    }
+  },
+  {
+    "type": "console.navigation/separator",
+    "properties": {
       "perspective": "admin",
-      "name": "%plugin__forklift-console-plugin~VM Import%",
-      "insertAfter": "workloads"
+      "section": "virtualization",
+      "id": "importSeparator",
+      "insertAfter": "migrationpolicies",
+      "testID": "ImportSeparator"
+    },
+    "flags": {
+      "required": [
+        "KUBEVIRT_DYNAMIC"
+      ]
     }
   },
   {
     "type": "console.navigation/href",
     "properties": {
       "id": "providers",
+      "insertAfter": "importSeparator",
       "perspective": "admin",
-      "section": "migrationtoolkit",
-      "name": "%plugin__forklift-console-plugin~Providers%",
+      "section": "virtualization",
+      "name": "%plugin__forklift-console-plugin~Providers for VM Import%",
       "href": "/mtv/providers"
     }
   },
   {
     "type": "console.navigation/href",
     "properties": {
-      "id": "mappings",
-      "perspective": "admin",
-      "section": "migrationtoolkit",
-      "name": "%plugin__forklift-console-plugin~Mappings%",
-      "href": "/mtv/mappings"
+      "id": "plans",
+      "insertAfter": "providers",
+      "section": "virtualization",
+      "name": "%plugin__forklift-console-plugin~Plans for VM Import%",
+      "href": "/mtv/plans"
     }
   },
   {
     "type": "console.navigation/href",
     "properties": {
-      "id": "plans",
-      "section": "migrationtoolkit",
-      "name": "%plugin__forklift-console-plugin~Plans%",
-      "href": "/mtv/plans"
+      "id": "mappings",
+      "insertAfter": "plans",
+      "perspective": "admin",
+      "section": "virtualization",
+      "name": "%plugin__forklift-console-plugin~Mappings for VM Import%",
+      "href": "/mtv/mappings"
     }
   },
   {

--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -1,7 +1,6 @@
 {
-  "NetworkMaps": "NetworkMaps",
-  "Plans": "Plans",
-  "Providers": "Providers",
-  "StorageMaps": "StorageMaps",
-  "VM Import": "VM Import"
+  "Mappings for VM Import": "Mappings for VM Import",
+  "Plans for VM Import": "Plans for VM Import",
+  "Providers for VM Import": "Providers for VM Import",
+  "Virtualization": "Virtualization"
 }

--- a/scripts/start-console-k8s.sh
+++ b/scripts/start-console-k8s.sh
@@ -54,13 +54,13 @@ export BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001,kubevirt-plugn=http://localhost:9002"
         podman run --pull always --rm --network=host --env "BRIDGE_*" $CONSOLE_IMAGE
     else
-        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001,kubevirt-plugn=http://localhost:9002"
         podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env "BRIDGE_*" $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
+    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001,kubevirt-plugn=http://localhost:9002"
     docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep ^BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
 fi

--- a/scripts/start-console-with-oauth.sh
+++ b/scripts/start-console-with-oauth.sh
@@ -83,13 +83,13 @@ export BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001,kubevirt-plugn=http://localhost:9002"
         podman run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z --network=host --env "BRIDGE_*" $CONSOLE_IMAGE
     else
-        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001,kubevirt-plugn=http://localhost:9002"
         podman run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z -p "$CONSOLE_PORT":9000 --env "BRIDGE_*" $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
+    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001,kubevirt-plugn=http://localhost:9002"
     docker run --pull always --rm -v $(pwd)/tmp:/mnt/config:Z -p "$CONSOLE_PORT":9000 --env-file <(set | grep ^BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
 fi

--- a/scripts/start-console.sh
+++ b/scripts/start-console.sh
@@ -47,13 +47,13 @@ export BRIDGE_PLUGIN_PROXY=$(echo ${PLUGIN_PROXY} | sed 's/[ \n]//g')
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001,kubevirt-plugin=http://localhost:9002"
         podman run --pull always --rm --network=host --env "BRIDGE_*" $CONSOLE_IMAGE
     else
-        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+        export BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001,kubevirt-plugin=http://localhost:9002"
         podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env "BRIDGE_*" $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
+    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001,kubevirt-plugin=http://localhost:9002"
     docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep ^BRIDGE | sed "s/'//g") $CONSOLE_IMAGE
 fi

--- a/src/internal/i18n/i18n.ts
+++ b/src/internal/i18n/i18n.ts
@@ -3,11 +3,10 @@ import { useTranslation as useReactI18NextTranslation } from 'react-i18next';
 // IMPORTANT: This file adds comments recognized by the react-i18next-parser so that
 // labels declared in console-extensions.json are added to the message catalog.
 
-// t('plugin__forklift-console-plugin~VM Import')
-// t('plugin__forklift-console-plugin~Providers')
-// t('plugin__forklift-console-plugin~Plans')
-// t('plugin__forklift-console-plugin~NetworkMaps')
-// t('plugin__forklift-console-plugin~StorageMaps')
+// t('plugin__forklift-console-plugin~Virtualization')
+// t('plugin__forklift-console-plugin~Providers for VM Import')
+// t('plugin__forklift-console-plugin~Plans for VM Import')
+// t('plugin__forklift-console-plugin~Mappings for VM Import')
 
 export function useTranslation() {
   return useReactI18NextTranslation('plugin__forklift-console-plugin');


### PR DESCRIPTION
Move Forklift menu items to be under the virtualization section in the menu.

Forklift operators are moving from "Konveyor" project to be part of "Kubevirt" project, it makes sense that the menu items will also reflect this change.

If kubevirt plugin is not enabled:
  - add virtualization section
  - add import items below it

if kubevirt plugin is enabled:
 - add a separator ( after "migrationpolicies", witch is the last item in virtualization menu as of 4.12 )
 - add import items below the separator

Screenshots:
The movie:
![mtv+cnv](https://user-images.githubusercontent.com/2181522/191067281-d810f75e-c00a-4bf0-8c22-b54806a509d8.gif)

Before:
![vm-import-section](https://user-images.githubusercontent.com/2181522/190978455-90d40760-d7d5-4e8b-9910-13d5cce17cf7.png)

After:
![virt-section](https://user-images.githubusercontent.com/2181522/190978631-affeb761-8499-4c66-a443-3deb5db390ed.png)

After with kubevirt plugin running:
![screenshot-localhost_9000-2022 09 19-19_23_18](https://user-images.githubusercontent.com/2181522/191068057-9bc9c2db-a1be-41f7-914a-9b82e0238f9d.png)

Signed-off-by: yzamir <yzamir@redhat.com>