### PR TITLE
Extract provider status mapper

### DIFF
--- a/pkg/web/src/app/common/components/StatusCondition.tsx
+++ b/pkg/web/src/app/common/components/StatusCondition.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { StatusIcon, StatusType } from '@migtools/lib-ui';
-import { getMostSeriousCondition } from '@app/common/helpers';
+import { StatusIcon } from '@migtools/lib-ui';
+import { getMostSeriousCondition, getStatusType } from '@app/common/helpers';
 import { StatusCategoryType } from '@app/common/constants';
 import { IStatusCondition } from '@app/queries/types';
 import { Button, Popover } from '@patternfly/react-core';
@@ -21,22 +21,6 @@ export const StatusCondition: React.FunctionComponent<IStatusConditionProps> = (
   popoverBodyId,
 }: IStatusConditionProps) => {
   if (!status) return <StatusIcon status="Loading" label="Validating" />;
-
-  const getStatusType = (severity: string): StatusType => {
-    if (severity === 'Ready' || severity === StatusCategoryType.Required) {
-      return 'Ok';
-    }
-    if (severity === StatusCategoryType.Advisory) {
-      return 'Info';
-    }
-    if (severity === 'Pending') {
-      return 'Loading';
-    }
-    if (severity === StatusCategoryType.Critical || severity === StatusCategoryType.Error) {
-      return 'Error';
-    }
-    return 'Warning';
-  };
 
   const conditions = status?.conditions || [];
   const mostSeriousCondition = getMostSeriousCondition(conditions);

--- a/pkg/web/src/app/common/helpers.ts
+++ b/pkg/web/src/app/common/helpers.ts
@@ -13,6 +13,7 @@ import {
 } from '@app/queries/types';
 import { UseQueryResult } from 'react-query';
 import { IKubeList } from '@app/client/types';
+import { StatusType } from '@migtools/lib-ui';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -27,6 +28,22 @@ export const findConditionByCategory = (
   category: string
 ): IStatusCondition | undefined => {
   return conditions.find((condition) => condition.category === category);
+};
+
+export const getStatusType = (severity: string): StatusType => {
+  if (severity === 'Ready' || severity === StatusCategoryType.Required) {
+    return 'Ok';
+  }
+  if (severity === StatusCategoryType.Advisory) {
+    return 'Info';
+  }
+  if (severity === 'Pending') {
+    return 'Loading';
+  }
+  if (severity === StatusCategoryType.Critical || severity === StatusCategoryType.Error) {
+    return 'Error';
+  }
+  return 'Warning';
 };
 
 export const getMostSeriousCondition = (conditions: IStatusCondition[]): string => {


### PR DESCRIPTION
Refactoring moved to dedicated PR for visibility as suggested in [this review ](https://github.com/konveyor/forklift-console-plugin/pull/33#discussion_r970772412)

Note that provider resource has no summary status provided by the backend - the condition to state mapping is calculated only in the frontend.