### PR TITLE
Point helm charts to use released version

### DIFF
--- a/deployment/forklift-console-plugin/values.yaml
+++ b/deployment/forklift-console-plugin/values.yaml
@@ -1,5 +1,5 @@
 plugin: forklift-console-plugin
 name: forklift-console-plugin
-image: quay.io/kubevirt-ui/forklift-console-plugin:latest
+image: quay.io/kubevirt-ui/forklift-console-plugin:release-v0.1
 
 forkliftNamespace: konveyor-forklift

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -17,7 +17,7 @@
 |-----------|-------------|---------------|
 | plugin | name of "app" label used for objects |  forklift-console-plugin
 | name | the deployment name | forklift-console-plugin
-| image | the plugin container image | quay.io/kubevirt-ui/forklift-console-plugin:latest
+| image | the plugin container image | quay.io/kubevirt-ui/forklift-console-plugin:[latest release branch]
 | forkliftNamespace | forklift-operator namespace | konveyor-forklift
 
 ## Running the helm chart locally


### PR DESCRIPTION
We currently point Helm deployments to use `main` branch, as we are moving to use `main` as an unstable development branch, changing the default image to be a released version.