### PR TITLE
 Support more customizations in ConfirmModal

### DIFF
--- a/pkg/web/src/app/common/components/ConfirmModal.tsx
+++ b/pkg/web/src/app/common/components/ConfirmModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal, Stack, Flex, Button, ModalProps } from '@patternfly/react-core';
+import { Modal, Stack, Flex, Button, ModalProps, ButtonProps } from '@patternfly/react-core';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
 import { UnknownMutationResult } from '../types';
 
@@ -16,7 +16,10 @@ export interface IConfirmModalProps {
   confirmButtonText: string;
   cancelButtonText?: string;
   confirmButtonDisabled?: boolean;
+  confirmButtonVariant?: ButtonProps['variant'];
   errorText?: string;
+  position?: ModalProps['position'];
+  titleIconVariant?: ModalProps['titleIconVariant'];
 }
 
 export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
@@ -29,15 +32,20 @@ export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
   body,
   confirmButtonText,
   confirmButtonDisabled = false,
+  confirmButtonVariant = 'primary',
   cancelButtonText = 'Cancel',
   errorText = 'Error performing action',
+  position,
+  titleIconVariant = undefined,
 }: IConfirmModalProps) =>
   isOpen ? (
     <Modal
       variant={variant}
       title={title}
+      titleIconVariant={titleIconVariant}
       isOpen
       onClose={toggleOpen}
+      position={position}
       footer={
         <Stack hasGutter>
           {mutateResult ? (
@@ -51,7 +59,7 @@ export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
             <Button
               id="modal-confirm-button"
               key="confirm"
-              variant="primary"
+              variant={confirmButtonVariant}
               onClick={mutateFn}
               isDisabled={mutateResult?.isLoading || confirmButtonDisabled}
             >


### PR DESCRIPTION
New props allow better alignment with Console look&feel

#### Delete pod confirmation dialog
1. displayed near the top of the screen (not in the middle)
2. warning icon in the title section
3. primary action uses "danger" styling

![image](https://user-images.githubusercontent.com/64194103/193328533-7086e9e1-a848-4064-bbdb-565509c3bc34.png)

#### Delete provider confirmation dialog using new props

![image](https://user-images.githubusercontent.com/64194103/193328693-d53f3675-6264-4ca3-89e9-0555c0b43e69.png)

#### Delete provider confirmation dialog with default styling

![image](https://user-images.githubusercontent.com/64194103/193330120-ecabeb61-5c2c-4ed8-9cd8-484af2dc02d7.png)

