### PR TITLE
Use real 'kind' for Providers in mock data

### DIFF
--- a/pkg/web/src/app/queries/mocks/providers.mock.ts
+++ b/pkg/web/src/app/queries/mocks/providers.mock.ts
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     type: 'vsphere',
     object: {
       apiVersion: '12345',
-      kind: 'foo-kind',
+      kind: 'forklift.konveyor.io~v1beta1~Provider',
       metadata: {
         name: 'vcenter-1',
         namespace: 'openshift-migration',
@@ -164,7 +164,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     selfLink: 'providers/ovirt/foo1',
     type: 'ovirt',
     object: {
-      kind: 'Provider',
+      kind: 'forklift.konveyor.io~v1beta1~Provider',
       apiVersion: 'forklift.konveyor.io/v1beta1',
       metadata: {
         name: 'rhv-1',
@@ -267,7 +267,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     type: 'openshift',
     object: {
       apiVersion: '12345',
-      kind: 'foo-kind',
+      kind: 'forklift.konveyor.io~v1beta1~Provider',
       metadata: {
         name: 'ocpv-1',
         namespace: 'openshift-migration',


### PR DESCRIPTION
Value of the 'kind' property: `forklift.konveyor.io~v1beta1~Provider`.

Values previously used  result in malformed labels generated by the Console (see below)

![image](https://user-images.githubusercontent.com/64194103/193332168-85766b95-7807-4577-9550-d52384bcd44b.png)
